### PR TITLE
Text entity tidy

### DIFF
--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -290,7 +290,7 @@ mod tests {
     use bevy_app::{App, Update};
     use bevy_asset::{load_internal_binary_asset, Handle};
     use bevy_ecs::{event::Events, schedule::IntoSystemConfigs};
-    use bevy_hierarchy::{BuildChildren, ChildBuild as _};
+    use bevy_hierarchy::BuildChildren;
     use bevy_utils::default;
 
     use super::*;
@@ -322,22 +322,15 @@ mod tests {
             |bytes: &[u8], _path: String| { Font::try_from_bytes(bytes.to_vec()).unwrap() }
         );
 
-        let mut text_entity = Entity::from_raw(0);
+        let text_entity = app
+            .world_mut()
+            .spawn(TextSection::new(FIRST_TEXT, default()))
+            .id();
 
         let entity = app
             .world_mut()
-            .spawn((Text2dBundle {
-                text: Text::default(),
-                ..default()
-            },))
-            .with_children(|c| {
-                text_entity = c
-                    .spawn(TextSection {
-                        value: FIRST_TEXT.to_string(),
-                        style: default(),
-                    })
-                    .id();
-            })
+            .spawn(Text2dBundle::default())
+            .add_child(text_entity)
             .id();
 
         (app, entity, text_entity)
@@ -391,10 +384,7 @@ mod tests {
             .expect("Could not find entity");
         *entity_ref
             .get_mut::<TextSection>()
-            .expect("Missing Text on entity") = TextSection {
-            value: SECOND_TEXT.to_string(),
-            style: default(),
-        };
+            .expect("Missing Text on entity") = TextSection::new(SECOND_TEXT, default());
 
         // Recomputes the AABB.
         app.update();

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -25,9 +25,10 @@ fn calc_name(
     children: &Children,
 ) -> Option<Box<str>> {
     let mut name = None;
+    let mut sections = Vec::new();
     for child in children {
         if let Ok(maybe_children) = texts.get(*child) {
-            let mut sections = Vec::new();
+            sections.clear();
 
             if let Ok(section) = text_sections.get(*child) {
                 sections.push(section);
@@ -39,14 +40,22 @@ fn calc_name(
                 }
             }
 
-            let values = sections
-                .iter()
-                .map(|v| v.value.to_string())
-                .collect::<Vec<String>>();
-            name = Some(values.join(" "));
+            let iterator = sections.iter().map(|v| v.value.as_ref());
+            name = Some(join_strs(iterator, " "));
         }
     }
     name.map(String::into_boxed_str)
+}
+
+fn join_strs<'a>(values: impl Iterator<Item = &'a str>, sep: &str) -> String {
+    let mut s = String::new();
+    for (i, value) in values.enumerate() {
+        if i > 0 {
+            s.push_str(sep);
+        }
+        s.push_str(value);
+    }
+    s
 }
 
 fn calc_bounds(

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -80,7 +80,7 @@ fn setup(
         })
         .with_child(TextSection::new(
             "Press space to toggle wireframes",
-            TextStyle::default(),
+            default(),
         ));
 }
 

--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -148,6 +148,6 @@ fn setup(
         }))
         .with_child(TextSection::new(
             "Left Arrow Key: Animate Left Sprite\nRight Arrow Key: Animate Right Sprite",
-            TextStyle::default(),
+            default(),
         ));
 }

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -150,7 +150,7 @@ fn setup(
         }))
         .with_child(TextSection::new(
             "Press space to toggle wireframes",
-            TextStyle::default(),
+            default(),
         ));
 }
 

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -290,7 +290,7 @@ impl AppStatus {
         // Build the `Text` object.
         TextSection::new(
             format!("{}\n{}", material_variant_help_text, light_help_text),
-            TextStyle::default(),
+            default(),
         )
     }
 }

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -102,7 +102,7 @@ fn setup_instructions(mut commands: Commands) {
         ..default()
     })).with_child(TextSection::new(
         "Press Spacebar to Toggle Atmospheric Fog.\nPress S to Toggle Directional Light Fog Influence.",
-        TextStyle::default(),
+        default(),
     ));
 }
 

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -132,8 +132,6 @@ fn setup(
         ..default()
     });
 
-    let text_style = TextStyle::default();
-
     commands.spawn(TextBundle::default().with_style(Style {
         position_type: PositionType::Absolute,
         top: Val::Px(12.0),
@@ -141,7 +139,7 @@ fn setup(
         ..default()
     })).with_child(TextSection::new(
         "Left / Right - Rotate Camera\nC - Toggle Compensation Curve\nM - Toggle Metering Mask\nV - Visualize Metering Mask",
-        text_style.clone(),
+        default(),
     ));
 
     commands
@@ -151,7 +149,7 @@ fn setup(
             right: Val::Px(10.0),
             ..default()
         }))
-        .with_child((TextSection::from_style(text_style), ExampleDisplay));
+        .with_child((TextSection::default(), ExampleDisplay));
 }
 
 #[derive(Component)]

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -335,6 +335,6 @@ impl LightMode {
             LightMode::Directional => "Press Space to switch to a point light",
         };
 
-        TextSection::new(help_text, TextStyle::default())
+        TextSection::new(help_text, default())
     }
 }

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -73,7 +73,7 @@ fn setup(
         }))
         .with_child(TextSection::new(
             "Controls:\nSpace: Change UVs\nX/Y/Z: Rotate\nR: Reset orientation",
-            TextStyle::default(),
+            default(),
         ));
 }
 

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -354,7 +354,7 @@ impl AppStatus {
                 rotation_help_text,
                 switch_mesh_help_text
             ),
-            TextStyle::default(),
+            default(),
         )
     }
 }

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -240,7 +240,6 @@ fn setup(
     });
 
     // example instructions
-    let style = TextStyle::default();
 
     commands
         .spawn(TextBundle {
@@ -256,7 +255,7 @@ fn setup(
             root.spawn((
                 TextSection::new(
                     format!("Aperture: f/{:.0}\n", parameters.aperture_f_stops),
-                    style.clone(),
+                    default(),
                 ),
                 ApertureText,
             ));
@@ -267,7 +266,7 @@ fn setup(
                         "Shutter speed: 1/{:.0}s\n",
                         1.0 / parameters.shutter_speed_s
                     ),
-                    style.clone(),
+                    default(),
                 ),
                 ShutterSpeedText,
             ));
@@ -275,7 +274,7 @@ fn setup(
             root.spawn((
                 TextSection::new(
                     format!("Sensitivity: ISO {:.0}\n", parameters.sensitivity_iso),
-                    style.clone(),
+                    default(),
                 ),
                 SensitivityText,
             ));
@@ -290,7 +289,7 @@ fn setup(
                     5/6 - Decrease/Increase sensitivity\n\
                     R - Reset exposure"]
                 .join("\n"),
-                style.clone(),
+                default(),
             ));
         });
 

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -258,8 +258,6 @@ fn spawn_trees(
 }
 
 fn setup_ui(mut commands: Commands) {
-    let style = TextStyle::default();
-
     commands
         .spawn(TextBundle {
             style: Style {
@@ -271,18 +269,15 @@ fn setup_ui(mut commands: Commands) {
             ..default()
         })
         .with_children(|root| {
-            root.spawn((
-                TextSection::new(String::new(), style.clone()),
-                ShutterAngleText,
-            ));
+            root.spawn((TextSection::default(), ShutterAngleText));
 
-            root.spawn((TextSection::new(String::new(), style.clone()), SamplesText));
+            root.spawn((TextSection::default(), SamplesText));
 
             root.spawn(TextSection::new(
                 "1/2: -/+ shutter angle (blur amount)\n\
                     3/4: -/+ sample count (blur quality)\n\
                     Spacebar: cycle camera",
-                style,
+                default(),
             ));
         });
 }

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -310,8 +310,6 @@ fn setup(
     commands.spawn(background_cube_bundle(Vec3::new(0., 0., 45.)));
     commands.spawn(background_cube_bundle(Vec3::new(0., 0., -45.)));
 
-    let style = TextStyle::default();
-
     // example instructions
     commands
         .spawn(TextBundle {
@@ -327,21 +325,18 @@ fn setup(
             root.spawn((
                 TextSection::new(
                     format!("Parallax depth scale: {parallax_depth_scale:.5}"),
-                    style.clone(),
+                    default(),
                 ),
                 ParallaxDepthText,
             ));
 
             root.spawn((
-                TextSection::new(
-                    format!("Layers: {max_parallax_layer_count:.0}"),
-                    style.clone(),
-                ),
+                TextSection::new(format!("Layers: {max_parallax_layer_count:.0}"), default()),
                 ParallaxLayersText,
             ));
 
             root.spawn((
-                TextSection::new(format!("{parallax_mapping_method}"), style.clone()),
+                TextSection::new(format!("{parallax_mapping_method}"), default()),
                 ParallaxMethodText,
             ));
 
@@ -355,7 +350,7 @@ fn setup(
                     "Space - Switch parallaxing algorithm",
                 ]
                 .join("\n"),
-                style.clone(),
+                default(),
             ));
         });
 }

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -159,7 +159,7 @@ fn create_help_text(app_settings: &AppSettings) -> TextSection {
             "Chromatic aberration intensity: {} (Press Left or Right to change)",
             app_settings.chromatic_aberration_intensity
         ),
-        TextStyle::default(),
+        default(),
     )
 }
 

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -284,7 +284,7 @@ impl AppStatus {
                 "{}\n{}\n{}",
                 self.reflection_mode, rotation_help_text, REFLECTION_MODE_HELP_TEXT
             ),
-            TextStyle::default(),
+            default(),
         )
     }
 }

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -134,8 +134,6 @@ fn setup(
         ..default()
     });
 
-    let style = TextStyle::default();
-
     commands
         .spawn(TextBundle {
             style: Style {
@@ -158,47 +156,41 @@ fn setup(
                 5/6   - change direction light depth bias\n\
                 7/8   - change direction light normal bias\n\
                 left/right/up/down/pgup/pgdown - adjust light position (looking at 0,0,0)",
-                style.clone(),
+                default(),
             ));
 
             c.spawn((
-                TextSection::new("Current Lights: [DirectionalLight]", style.clone()),
+                TextSection::new("Current Lights: [DirectionalLight]", default()),
                 LightTypeText,
             ));
 
             c.spawn((
-                TextSection::new(
-                    "Current Directional Light Filter: [Hardware2x2]",
-                    style.clone(),
-                ),
+                TextSection::new("Current Directional Light Filter: [Hardware2x2]", default()),
                 LightFilterText,
             ));
 
             c.spawn((
-                TextSection::new("Current Point Light Depth Bias: [0.00]", style.clone()),
+                TextSection::new("Current Point Light Depth Bias: [0.00]", default()),
                 PointLightDepthBiasText,
             ));
 
             c.spawn((
-                TextSection::new("Current Point Light Normal Bias: [0.0]", style.clone()),
+                TextSection::new("Current Point Light Normal Bias: [0.0]", default()),
                 PointLightNormalBiasText,
             ));
 
             c.spawn((
-                TextSection::new("Current Directional Light Depth Bias: [0.0]", style.clone()),
+                TextSection::new("Current Directional Light Depth Bias: [0.0]", default()),
                 DirectionalLightDepthBiasText,
             ));
 
             c.spawn((
-                TextSection::new(
-                    "Current Directional Light Normal Bias: [0.0]",
-                    style.clone(),
-                ),
+                TextSection::new("Current Directional Light Normal Bias: [0.0]", default()),
                 DirectionalLightNormalBiasText,
             ));
 
             c.spawn((
-                TextSection::new("Current Light Position: [0, 0, 0]", style.clone()),
+                TextSection::new("Current Light Position: [0, 0, 0]", default()),
                 LightPositionText,
             ));
         });

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -108,7 +108,7 @@ fn setup(
                         left: Val::Px(12.),
                         ..default()
                     }))
-                    .with_child(TextSection::new(*camera_name, TextStyle::default()));
+                    .with_child(TextSection::new(*camera_name, default()));
                 buttons_panel(parent);
             });
     }
@@ -156,7 +156,7 @@ fn setup(
             .with_children(|parent| {
                 parent
                     .spawn(TextBundle::default())
-                    .with_child(TextSection::new(caption, TextStyle::default()));
+                    .with_child(TextSection::new(caption, default()));
             });
     }
 }

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -143,7 +143,7 @@ fn setup(
             left: Val::Px(12.0),
             ..default()
         }))
-        .with_child(TextSection::new(INSTRUCTIONS, TextStyle::default()));
+        .with_child(TextSection::new(INSTRUCTIONS, default()));
 }
 
 fn light_sway(time: Res<Time>, mut query: Query<(&mut Transform, &mut SpotLight)>) {

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -281,7 +281,7 @@ fn create_text(app_settings: &AppSettings) -> TextSection {
             },
             MOVE_CAMERA_HELP_TEXT
         ),
-        TextStyle::default(),
+        default(),
     )
 }
 

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -324,7 +324,7 @@ Press WASD or use the mouse wheel to move the camera",
                     ' '
                 },
             ),
-            TextStyle::default(),
+            default(),
         )
     }
 }

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -76,7 +76,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         }))
         .with_child(TextSection::new(
             "Press WASD or the arrow keys to change the light direction",
-            TextStyle::default(),
+            default(),
         ));
 }
 

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -263,7 +263,7 @@ fn setup_help_text(commands: &mut Commands) {
             },
             ..default()
         })
-        .with_child(TextSection::new(HELP_TEXT, TextStyle::default()));
+        .with_child(TextSection::new(HELP_TEXT, default()));
 }
 
 /// Initializes the node UI widgets.

--- a/examples/app/log_layers_ecs.rs
+++ b/examples/app/log_layers_ecs.rs
@@ -142,7 +142,7 @@ fn print_logs(
 
     commands.entity(root_entity).with_children(|child| {
         for event in events.read() {
-            child.spawn(TextSection::new(&event.message, TextStyle::default()));
+            child.spawn(TextSection::new(&event.message, default()));
         }
     });
 }

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -30,7 +30,7 @@ fn setup(mut commands: Commands) {
             },
             ..default()
         })
-        .with_child(TextSection::new("Press P to panic", TextStyle::default()));
+        .with_child(TextSection::new("Press P to panic", default()));
 }
 
 fn panic_on_p(keys: Res<ButtonInput<KeyCode>>) {

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -54,8 +54,6 @@ fn read_stream(receiver: Res<StreamReceiver>, mut events: EventWriter<StreamEven
 }
 
 fn spawn_text(mut commands: Commands, mut reader: EventReader<StreamEvent>) {
-    let text_style = TextStyle::default();
-
     for (per_frame, event) in reader.read().enumerate() {
         commands
             .spawn(Text2dBundle {
@@ -63,7 +61,7 @@ fn spawn_text(mut commands: Commands, mut reader: EventReader<StreamEvent>) {
                 transform: Transform::from_xyz(per_frame as f32 * 100.0, 300.0, 0.0),
                 ..default()
             })
-            .with_child(TextSection::new(event.0.to_string(), text_style.clone()));
+            .with_child(TextSection::new(event.0.to_string(), default()));
     }
 }
 

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -84,7 +84,7 @@ fn setup(
         }))
         .with_child(TextSection::new(
             "Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement",
-            TextStyle::default(),
+            default(),
         ));
 
     // camera

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -74,7 +74,7 @@ fn setup(
         }))
         .with_child(TextSection::new(
             "Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement",
-            TextStyle::default(),
+            default(),
         ));
 
     // camera

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -68,7 +68,7 @@ fn setup_instructions(mut commands: Commands) {
         }))
         .with_child(TextSection::new(
             "Move the light with WASD.\nThe camera will smoothly track the light.",
-            TextStyle::default(),
+            default(),
         ));
 }
 

--- a/examples/ecs/one_shot_systems.rs
+++ b/examples/ecs/one_shot_systems.rs
@@ -114,7 +114,7 @@ fn setup_ui(mut commands: Commands) {
                 .with_child(TextSection::new(
                     "Press A or B to trigger a one-shot system\n\n\
     Last Triggered: ",
-                    TextStyle::default(),
+                    default(),
                 ));
 
             root.spawn(TextBundle::default()).with_child((

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -33,7 +33,7 @@ fn setup(mut commands: Commands) {
     Press '1' / '2' to toggle the visibility of straight / round gizmos\n\
     Press 'U' / 'I' to cycle through line styles\n\
     Press 'J' / 'K' to cycle through line joins",
-            TextStyle::default(),
+            default(),
         ));
 }
 

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -72,7 +72,7 @@ fn setup(
         Press 'B' to show all AABB boxes\n\
         Press 'U' or 'I' to cycle through line styles for straight or round gizmos\n\
         Press 'J' or 'K' to cycle through line joins for straight or round gizmos",
-            TextStyle::default(),
+            default(),
         ));
 }
 

--- a/examples/gizmos/light_gizmos.rs
+++ b/examples/gizmos/light_gizmos.rs
@@ -107,8 +107,6 @@ fn setup(
 
     // Example instructions and gizmo config.
     {
-        let text_style = TextStyle::default();
-
         commands
             .spawn(TextBundle::default().with_style(Style {
                 position_type: PositionType::Absolute,
@@ -121,7 +119,7 @@ fn setup(
         Hold 'Left' or 'Right' to change the line width of the gizmos\n\
         Press 'A' to toggle drawing of the light gizmos\n\
         Press 'C' to cycle between the light gizmos coloring modes",
-                text_style.clone(),
+                default(),
             ));
 
         let (_, light_config) = config_store.config_mut::<LightGizmoConfigGroup>();
@@ -136,11 +134,11 @@ fn setup(
                 ..default()
             }),))
             .with_children(|parent| {
-                parent.spawn(TextSection::new("Gizmo color mode: ", text_style.clone()));
+                parent.spawn(TextSection::new("Gizmo color mode: ", default()));
 
                 parent.spawn((
                     GizmoColorText,
-                    TextSection::new(gizmo_color_text(light_config), text_style),
+                    TextSection::new(gizmo_color_text(light_config), default()),
                 ));
             });
     }

--- a/examples/math/cubic_splines.rs
+++ b/examples/math/cubic_splines.rs
@@ -75,7 +75,6 @@ fn setup(mut commands: Commands) {
         C: Toggle cyclic curve construction";
     let spline_mode_text = format!("Spline: {}", spline_mode);
     let cycling_mode_text = format!("{}", cycling_mode);
-    let style = TextStyle::default();
 
     commands
         .spawn(NodeBundle {
@@ -91,14 +90,14 @@ fn setup(mut commands: Commands) {
         })
         .with_children(|parent| {
             parent.spawn(TextBundle::default()).with_children(|parent| {
-                parent.spawn(TextSection::new(instructions_text, style.clone()));
+                parent.spawn(TextSection::new(instructions_text, default()));
                 parent.spawn((
                     SplineModeText,
-                    TextSection::new(spline_mode_text, style.clone()),
+                    TextSection::new(spline_mode_text, default()),
                 ));
                 parent.spawn((
                     CyclingModeText,
-                    TextSection::new(cycling_mode_text, style.clone()),
+                    TextSection::new(cycling_mode_text, default()),
                 ));
             });
         });

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -180,7 +180,7 @@ fn setup(
     ).with_child(TextSection::new(
         "Press 'B' to toggle between no bounding shapes, bounding boxes (AABBs) and bounding spheres / circles\n\
         Press 'Space' to switch between 3D and 2D",
-        TextStyle::default(),
+        default(),
     ));
 }
 

--- a/examples/math/random_sampling.rs
+++ b/examples/math/random_sampling.rs
@@ -126,7 +126,7 @@ fn setup(
         S: Add one random sample.\n\
         D: Add 100 random samples.\n\
         Rotate camera by holding left mouse and panning left/right.",
-            TextStyle::default(),
+            default(),
         ));
 
     // The mode starts with interior points.

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -373,7 +373,6 @@ fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
         .iter()
         .find_map(|(entity, camera)| camera.is_active.then_some(entity))
         .expect("run condition ensures existence");
-    let style = TextStyle::default();
 
     commands
         .spawn((
@@ -392,12 +391,12 @@ fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
             parent
                 .spawn(TextBundle::default().with_text_justify(JustifyText::Center))
                 .with_children(|parent| {
-                    parent.spawn(TextSection::new("Primitive: ", style.clone()));
+                    parent.spawn(TextSection::new("Primitive: ", default()));
 
                     parent.spawn((
                         TextSection::new(
                             format!("{text}", text = PrimitiveSelected::default()),
-                            style.clone(),
+                            default(),
                         ),
                         PrimitiveText,
                     ));
@@ -407,7 +406,7 @@ fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
                         Press 'C' to switch between 2D and 3D mode\n\
                         Press 'Up' or 'Down' to switch to the next/previous primitive\n\n\
                         (If nothing is displayed, there's no rendering support yet)",
-                        style.clone(),
+                        default(),
                     ));
                 });
         });

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -402,7 +402,7 @@ fn setup(
         Zoom camera by scrolling via mouse or +/-.\n\
         Move camera by L/R arrow keys.\n\
         Tab: Toggle this text",
-            TextStyle::default(),
+            default(),
         ));
 
     // No points are scheduled to spawn initially.

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -63,10 +63,7 @@ fn setup(
                 first.style.color = BLUE.into();
             },
         )
-        .with_child(TextSection::new(
-            "Click Me to get a box",
-            TextStyle::default(),
-        ));
+        .with_child(TextSection::new("Click Me to get a box", default()));
     // circular base
     commands
         .spawn((

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -139,8 +139,6 @@ fn setup(
         ..default()
     });
 
-    let style = TextStyle::default();
-
     commands
         .spawn(TextBundle::default().with_style(Style {
             position_type: PositionType::Absolute,
@@ -150,7 +148,7 @@ fn setup(
         }))
         .with_children(|parent| {
             parent.spawn((
-                TextSection::new("Prepass Output: transparent\n", style.clone()),
+                TextSection::new("Prepass Output: transparent\n", default()),
                 OutputText,
             ));
 
@@ -159,7 +157,7 @@ fn setup(
                 Controls\n\
                 ---------------\n\
                 Space - Change output\n",
-                style,
+                default(),
             ));
         });
 }

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -422,8 +422,6 @@ fn setup_triggers(
 }
 
 fn setup_connected(mut commands: Commands) {
-    let text_style = TextStyle::default();
-
     commands
         .spawn(TextBundle {
             style: Style {
@@ -435,17 +433,8 @@ fn setup_connected(mut commands: Commands) {
             ..default()
         })
         .with_children(|parent| {
-            parent.spawn(TextSection {
-                value: "Connected Gamepads:\n".to_string(),
-                style: text_style.clone(),
-            });
-            parent.spawn((
-                TextSection {
-                    value: "None".to_string(),
-                    style: text_style,
-                },
-                ConnectedGamepadsText,
-            ));
+            parent.spawn(TextSection::new("Connected Gamepads:\n", default()));
+            parent.spawn((TextSection::new("None", default()), ConnectedGamepadsText));
         });
 }
 

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -118,7 +118,7 @@ fn setup(
         Press 'T' to align the ship to those directions.\n\
         Click and drag the mouse to rotate the camera.\n\
         Press 'H' to hide/show these instructions.",
-            TextStyle::default(),
+            default(),
         ));
 
     commands.insert_resource(MousePressed(false));

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -15,8 +15,6 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
-    let text_style = TextStyle::default();
-
     let image = asset_server.load("branding/icon.png");
 
     commands
@@ -63,7 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             .with_children(|parent| {
                                 parent
                                     .spawn(TextBundle::default())
-                                    .with_child(TextSection::new(label, text_style.clone()));
+                                    .with_child(TextSection::new(label, default()));
                             });
                         parent
                             .spawn(NodeBundle {

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -79,8 +79,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // OverflowText
 
-    let text_style = TextStyle::default();
-
     commands
         .spawn(TextBundle::default().with_style(Style {
             position_type: PositionType::Absolute,
@@ -91,10 +89,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_children(|parent| {
             parent.spawn(TextSection::new(
                 "Next Overflow Setting (O)\nNext Container Size (S)\nToggle Animation (space)\n\n",
-                text_style.clone(),
+                default(),
             ));
             parent.spawn((
-                TextSection::new(format!("{:?}", Overflow::clip()), text_style.clone()),
+                TextSection::new(format!("{:?}", Overflow::clip()), default()),
                 OverflowText,
             ));
         });

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -333,7 +333,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     },
                                     Text::default(),
                                 ))
-                                .with_child(TextSection::new("Bevy logo", TextStyle::default()));
+                                .with_child(TextSection::new("Bevy logo", default()));
                         });
                 });
         });

--- a/examples/ui/ui_texture_atlas.rs
+++ b/examples/ui/ui_texture_atlas.rs
@@ -25,8 +25,6 @@ fn setup(
     // Camera
     commands.spawn(Camera2dBundle::default());
 
-    let text_style = TextStyle::default();
-
     let texture_handle = asset_server.load("textures/rpg/chars/gabe/gabe-idle-run.png");
     let texture_atlas = TextureAtlasLayout::from_grid(UVec2::splat(24), 7, 1, None, None);
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
@@ -40,7 +38,7 @@ fn setup(
                 flex_direction: FlexDirection::Column,
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                row_gap: Val::Px(text_style.font_size * 2.),
+                row_gap: Val::Px(TextStyle::default().font_size * 2.),
                 ..default()
             },
             ..default()
@@ -61,18 +59,15 @@ fn setup(
                 Outline::new(Val::Px(8.0), Val::ZERO, CRIMSON.into()),
             ));
             parent.spawn(TextBundle::default()).with_children(|parent| {
-                parent.spawn(TextSection::new("press ".to_string(), text_style.clone()));
+                parent.spawn(TextSection::new("press ", default()));
                 parent.spawn(TextSection::new(
-                    "space".to_string(),
+                    "space",
                     TextStyle {
                         color: YELLOW.into(),
-                        ..text_style.clone()
+                        ..default()
                     },
                 ));
-                parent.spawn(TextSection::new(
-                    " to advance frames".to_string(),
-                    text_style,
-                ));
+                parent.spawn(TextSection::new(" to advance frames", default()));
             });
         });
 }

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -54,13 +54,13 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_children(|parent| {
             parent
                 .spawn(TextBundle::default())
-                .with_child(TextSection::new("First window", TextStyle::default()));
+                .with_child(TextSection::new("First window", default()));
         });
     commands
         .spawn((NodeBundle::default(), TargetCamera(second_window_camera)))
         .with_children(|parent| {
             parent
                 .spawn(TextBundle::default())
-                .with_child(TextSection::new("Second window", TextStyle::default()));
+                .with_child(TextSection::new("Second window", default()));
         });
 }

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -70,6 +70,6 @@ fn setup(
         }))
         .with_child(TextSection::new(
             "Press <spacebar> to save a screenshot to disk",
-            TextStyle::default(),
+            default(),
         ));
 }


### PR DESCRIPTION
I haven't fully tested all of these changes but they are fairly mechanical:

1. The first two commits addresses some of the comments (some mine) in your PR https://github.com/bevyengine/bevy/pull/14572

2. The second two commits makes `TextSection` construction and `TextStyle` construction more uniform, since almost all examples are actually just using `TextStyle::default()`, and preferring `TextSection::new("text", default())`.
